### PR TITLE
Adding a point for separating IDs

### DIFF
--- a/apiaudit/apiauditform.md
+++ b/apiaudit/apiauditform.md
@@ -388,4 +388,10 @@ Any "No" answers must have an explanation in the comment field. Those implement
 <td colspan="1">Message integrity has been implemented according to the evaluated need?</td>
 <td colspan="1">yes</td>
 <td colspan="1">&nbsp;</td>
+<td colspan="1">&nbsp;</td></tr>
+<tr>
+<td colspan="1">&nbsp;</td>
+<td colspan="1">UUID used to identify object instead of internal ID?</td>
+<td colspan="1">yes</td>
+<td colspan="1">&nbsp;</td>
 <td colspan="1">&nbsp;</td></tr></tbody></table>


### PR DESCRIPTION
Exposing internal object ID (or database ID) as a reference for the resource is a bad idea for multiple reasons:
1. Service usage facts (as shown here: https://medium.freecodecamp.org/messing-with-the-google-buganizer-system-for-15-600-in-bounties-58f86cc9f9a5).
2. Easily iterate over objects.
3. In most cases, the database ID can't be easily changed in case that is needed.